### PR TITLE
[PLAT-1270] revert jackson update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,8 @@
         <findbugs.version>1.3.9</findbugs.version>
         <guava.version>29.0-jre</guava.version>
         <immutables.version>2.9.0</immutables.version>
-        <jackson.version>2.13.2.2</jackson.version>
+        <!-- do not update the jackson version, rest-api fails with the updated version -->
+        <jackson.version>2.13.2.2</jackson.version> 
         <junit.version>4.13.1</junit.version>
         <junitparams.version>1.1.1</junitparams.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <findbugs.version>1.3.9</findbugs.version>
         <guava.version>29.0-jre</guava.version>
         <immutables.version>2.9.0</immutables.version>
-        <jackson.version>2.13.3</jackson.version>
+        <jackson.version>2.13.2.2</jackson.version>
         <junit.version>4.13.1</junit.version>
         <junitparams.version>1.1.1</junitparams.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
Reverting the jackson version, the newer one causes rest-api builds to fail

## Summary
<!-- Implementation and architectural changes introduced. -->

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
